### PR TITLE
Switch to get_url to dodge proxy issue with apy_key.

### DIFF
--- a/tasks/repository/setup-Debian.yml
+++ b/tasks/repository/setup-Debian.yml
@@ -3,7 +3,7 @@
 
 - name: Debian | Add Puppetlabs apt key
   apt_key:
-    url: https://apt.puppetlabs.com/DEB-GPG-KEY-puppet
+    data: "{{ lookup('url', 'https://apt.puppetlabs.com/DEB-GPG-KEY-puppet', split_lines=False) }}"
     state: present
   when: ansible_distribution == "Debian" and ansible_distribution_major_version >= '08'
 

--- a/tasks/repository/setup-Ubuntu.yml
+++ b/tasks/repository/setup-Ubuntu.yml
@@ -3,7 +3,7 @@
 
 - name: Ubuntu | Add Puppetlabs apt key
   apt_key:
-    url: https://apt.puppetlabs.com/DEB-GPG-KEY-puppet
+    data: "{{ lookup('url', 'https://apt.puppetlabs.com/DEB-GPG-KEY-puppet', split_lines=False) }}"
     state: present
   when: ansible_distribution_major_version >= '16.04'
 


### PR DESCRIPTION
Hi there!  We have some Ubuntu machines behind a proxy and the apt_key call does not work behind one.  This is apparently a long known issue with ansible and there's a lot of discussion (almost arguing) about it.  While there are some indications that it is fixed in a 'soon' release of ansible, it definitely does not appear to be in the very latest per my testing.

A suggested workaround was to use locate inside a data param instead of the url param, which does respect your proxy settings.

Here are some interesting references from my research if you are interested in taking a look:

- [Where I found the locate workaround](https://github.com/ansible/ansible/issues/31691)
- [Where it outright indicates in the code that proxies aren't supported yet](https://github.com/ansible/ansible/blob/devel/lib/ansible/modules/apt_key.py#L210)

This seems to be a solid workaround and is functioning well in my testing.