### PR TITLE
Centos key fix

### DIFF
--- a/tasks/repository/setup-Amazon.yml
+++ b/tasks/repository/setup-Amazon.yml
@@ -10,7 +10,9 @@
     description: "Puppet {{ puppet_version }} Repository el {{ ansible_distribution_major_version }} - $basearch"
     baseurl: http://yum.puppetlabs.com/puppet{{ puppet_version }}/el/{{ el_version }}/$basearch
     gpgcheck: true
-    gpgkey: https://yum.puppet.com/RPM-GPG-KEY-puppet
+    gpgkey:
+      - 'https://yum.puppetlabs.com/RPM-GPG-KEY-puppet'
+      - 'https://yum.puppetlabs.com/RPM-GPG-KEY-puppet-20250406'
     enabled: true
     state: present
 
@@ -20,6 +22,8 @@
     description: "Puppet {{ puppet_version }} Repository el {{ ansible_distribution_major_version }} - Source"
     baseurl: http://yum.puppetlabs.com/puppet{{ puppet_version }}-nightly/el/{{ el_version }}/SRPMS
     gpgcheck: true
-    gpgkey: https://yum.puppet.com/RPM-GPG-KEY-puppet
+    gpgkey:
+      - 'https://yum.puppetlabs.com/RPM-GPG-KEY-puppet'
+      - 'https://yum.puppetlabs.com/RPM-GPG-KEY-puppet-20250406'
     enabled: true
     state: "{{ puppetlabs_repo_source }}"

--- a/tasks/repository/setup-Amazon.yml
+++ b/tasks/repository/setup-Amazon.yml
@@ -4,6 +4,16 @@
 - set_fact:
     el_version: "{{ (ansible_service_mgr == 'systemd') | ternary('7', '6') }}"
 
+- name: Amazonlinux | Add Puppetlabs rpm key
+  rpm_key:
+    state: present
+    key: "{{ item }}"
+  loop:
+    - 'http://yum.puppetlabs.com/RPM-GPG-KEY-puppet'
+    - 'http://yum.puppetlabs.com/RPM-GPG-KEY-puppet-20250406'
+    - 'http://yum.puppetlabs.com/RPM-GPG-KEY-puppetlabs'
+    - 'http://yum.puppetlabs.com/RPM-GPG-KEY-reductive'
+
 - name: Amazonlinux | Add Puppetlabs repository
   yum_repository:
     name: puppet{{ puppet_version }}

--- a/tasks/repository/setup-Amazon.yml
+++ b/tasks/repository/setup-Amazon.yml
@@ -21,8 +21,8 @@
     baseurl: http://yum.puppetlabs.com/puppet{{ puppet_version }}/el/{{ el_version }}/$basearch
     gpgcheck: true
     gpgkey:
-      - 'https://yum.puppetlabs.com/RPM-GPG-KEY-puppet'
-      - 'https://yum.puppetlabs.com/RPM-GPG-KEY-puppet-20250406'
+      - 'http://yum.puppetlabs.com/RPM-GPG-KEY-puppet'
+      - 'http://yum.puppetlabs.com/RPM-GPG-KEY-puppet-20250406'
     enabled: true
     state: present
 
@@ -33,7 +33,7 @@
     baseurl: http://yum.puppetlabs.com/puppet{{ puppet_version }}-nightly/el/{{ el_version }}/SRPMS
     gpgcheck: true
     gpgkey:
-      - 'https://yum.puppetlabs.com/RPM-GPG-KEY-puppet'
-      - 'https://yum.puppetlabs.com/RPM-GPG-KEY-puppet-20250406'
+      - 'http://yum.puppetlabs.com/RPM-GPG-KEY-puppet'
+      - 'http://yum.puppetlabs.com/RPM-GPG-KEY-puppet-20250406'
     enabled: true
     state: "{{ puppetlabs_repo_source }}"

--- a/tasks/repository/setup-CentOS.yml
+++ b/tasks/repository/setup-CentOS.yml
@@ -17,8 +17,8 @@
     baseurl: http://yum.puppetlabs.com/puppet{{ puppet_version }}/el/{{ ansible_distribution_major_version }}/$basearch
     gpgcheck: true
     gpgkey:
-      - 'https://yum.puppetlabs.com/RPM-GPG-KEY-puppet'
-      - 'https://yum.puppetlabs.com/RPM-GPG-KEY-puppet-20250406'
+      - 'http://yum.puppetlabs.com/RPM-GPG-KEY-puppet'
+      - 'http://yum.puppetlabs.com/RPM-GPG-KEY-puppet-20250406'
     enabled: true
     state: present
 
@@ -29,7 +29,7 @@
     baseurl: http://yum.puppetlabs.com/puppet{{ puppet_version }}-nightly/el/{{ ansible_distribution_major_version }}/SRPMS
     gpgcheck: true
     gpgkey:
-      - 'https://yum.puppetlabs.com/RPM-GPG-KEY-puppet'
-      - 'https://yum.puppetlabs.com/RPM-GPG-KEY-puppet-20250406'
+      - 'http://yum.puppetlabs.com/RPM-GPG-KEY-puppet'
+      - 'http://yum.puppetlabs.com/RPM-GPG-KEY-puppet-20250406'
     enabled: true
     state: "{{ puppetlabs_repo_source }}"

--- a/tasks/repository/setup-CentOS.yml
+++ b/tasks/repository/setup-CentOS.yml
@@ -1,5 +1,14 @@
 ---
 # add Puppetlabs repository in CentOS
+- name: CentOS | Add Puppetlabs rpm key
+  rpm_key:
+    state: present
+    key: "{{ item }}"
+  loop:
+    - 'http://yum.puppetlabs.com/RPM-GPG-KEY-puppet'
+    - 'http://yum.puppetlabs.com/RPM-GPG-KEY-puppet-20250406'
+    - 'http://yum.puppetlabs.com/RPM-GPG-KEY-puppetlabs'
+    - 'http://yum.puppetlabs.com/RPM-GPG-KEY-reductive'
 
 - name: CentOS | Add Puppetlabs repository
   yum_repository:

--- a/tasks/repository/setup-CentOS.yml
+++ b/tasks/repository/setup-CentOS.yml
@@ -7,7 +7,9 @@
     description: Puppet {{ puppet_version }} Repository el {{ ansible_distribution_major_version }} - $basearch
     baseurl: http://yum.puppetlabs.com/puppet{{ puppet_version }}/el/{{ ansible_distribution_major_version }}/$basearch
     gpgcheck: true
-    gpgkey: https://yum.puppet.com/RPM-GPG-KEY-puppet
+    gpgkey:
+      - 'https://yum.puppetlabs.com/RPM-GPG-KEY-puppet'
+      - 'https://yum.puppetlabs.com/RPM-GPG-KEY-puppet-20250406'
     enabled: true
     state: present
 
@@ -17,6 +19,8 @@
     description: Puppet {{ puppet_version }} Repository el {{ ansible_distribution_major_version }} - Source
     baseurl: http://yum.puppetlabs.com/puppet{{ puppet_version }}-nightly/el/{{ ansible_distribution_major_version }}/SRPMS
     gpgcheck: true
-    gpgkey: https://yum.puppet.com/RPM-GPG-KEY-puppet
+    gpgkey:
+      - 'https://yum.puppetlabs.com/RPM-GPG-KEY-puppet'
+      - 'https://yum.puppetlabs.com/RPM-GPG-KEY-puppet-20250406'
     enabled: true
     state: "{{ puppetlabs_repo_source }}"

--- a/tasks/repository/setup-Fedora.yml
+++ b/tasks/repository/setup-Fedora.yml
@@ -17,8 +17,8 @@
     baseurl: http://yum.puppetlabs.com/puppet{{ puppet_version }}/fedora/{{ ansible_distribution_major_version }}/$basearch
     gpgcheck: true
     gpgkey:
-      - 'https://yum.puppetlabs.com/RPM-GPG-KEY-puppet'
-      - 'https://yum.puppetlabs.com/RPM-GPG-KEY-puppet-20250406'
+      - 'http://yum.puppetlabs.com/RPM-GPG-KEY-puppet'
+      - 'http://yum.puppetlabs.com/RPM-GPG-KEY-puppet-20250406'
     enabled: true
     state: present
 
@@ -29,7 +29,7 @@
     baseurl: http://yum.puppetlabs.com/puppet{{ puppet_version }}-nightly/fedora/{{ ansible_distribution_major_version }}/SRPMS
     gpgcheck: true
     gpgkey:
-      - 'https://yum.puppetlabs.com/RPM-GPG-KEY-puppet'
-      - 'https://yum.puppetlabs.com/RPM-GPG-KEY-puppet-20250406'
+      - 'http://yum.puppetlabs.com/RPM-GPG-KEY-puppet'
+      - 'http://yum.puppetlabs.com/RPM-GPG-KEY-puppet-20250406'
     enabled: true
     state: "{{ puppetlabs_repo_source }}"

--- a/tasks/repository/setup-Fedora.yml
+++ b/tasks/repository/setup-Fedora.yml
@@ -1,5 +1,14 @@
 ---
 # add Puppetlabs repository in Fedora
+- name: Fedora | Add Puppetlabs rpm key
+  rpm_key:
+    state: present
+    key: "{{ item }}"
+  loop:
+    - 'http://yum.puppetlabs.com/RPM-GPG-KEY-puppet'
+    - 'http://yum.puppetlabs.com/RPM-GPG-KEY-puppet-20250406'
+    - 'http://yum.puppetlabs.com/RPM-GPG-KEY-puppetlabs'
+    - 'http://yum.puppetlabs.com/RPM-GPG-KEY-reductive'
 
 - name: Fedora | Add Puppetlabs repository
   yum_repository:

--- a/tasks/repository/setup-Fedora.yml
+++ b/tasks/repository/setup-Fedora.yml
@@ -7,7 +7,9 @@
     description: Puppet {{ puppet_version }} Repository fedora {{ ansible_distribution_major_version }} - $basearch
     baseurl: http://yum.puppetlabs.com/puppet{{ puppet_version }}/fedora/{{ ansible_distribution_major_version }}/$basearch
     gpgcheck: true
-    gpgkey: https://yum.puppet.com/RPM-GPG-KEY-puppet
+    gpgkey:
+      - 'https://yum.puppetlabs.com/RPM-GPG-KEY-puppet'
+      - 'https://yum.puppetlabs.com/RPM-GPG-KEY-puppet-20250406'
     enabled: true
     state: present
 
@@ -17,6 +19,8 @@
     description: Puppet {{ puppet_version }} Repository fedora {{ ansible_distribution_major_version }} - Source
     baseurl: http://yum.puppetlabs.com/puppet{{ puppet_version }}-nightly/fedora/{{ ansible_distribution_major_version }}/SRPMS
     gpgcheck: true
-    gpgkey: https://yum.puppet.com/RPM-GPG-KEY-puppet
+    gpgkey:
+      - 'https://yum.puppetlabs.com/RPM-GPG-KEY-puppet'
+      - 'https://yum.puppetlabs.com/RPM-GPG-KEY-puppet-20250406'
     enabled: true
     state: "{{ puppetlabs_repo_source }}"


### PR DESCRIPTION
Similar to what was fixed for SUSE, Puppet has begun pushing out packages build under it's new GPG key.  This patch performs a similar fix for the Red Hat family.  It does not touch Debian based systems, which likely also need a fix.  Most likely I'll be following this with a fix for them as well but focusing on the one that's causing me problems right now.  =)