### PR TITLE
Debian key fix

### DIFF
--- a/tasks/repository/setup-Amazon.yml
+++ b/tasks/repository/setup-Amazon.yml
@@ -10,7 +10,9 @@
     description: "Puppet {{ puppet_version }} Repository el {{ ansible_distribution_major_version }} - $basearch"
     baseurl: http://yum.puppetlabs.com/puppet{{ puppet_version }}/el/{{ el_version }}/$basearch
     gpgcheck: true
-    gpgkey: https://yum.puppet.com/RPM-GPG-KEY-puppet
+    gpgkey:
+      - 'https://yum.puppetlabs.com/RPM-GPG-KEY-puppet'
+      - 'https://yum.puppetlabs.com/RPM-GPG-KEY-puppet-20250406'
     enabled: true
     state: present
 
@@ -20,6 +22,8 @@
     description: "Puppet {{ puppet_version }} Repository el {{ ansible_distribution_major_version }} - Source"
     baseurl: http://yum.puppetlabs.com/puppet{{ puppet_version }}-nightly/el/{{ el_version }}/SRPMS
     gpgcheck: true
-    gpgkey: https://yum.puppet.com/RPM-GPG-KEY-puppet
+    gpgkey:
+      - 'https://yum.puppetlabs.com/RPM-GPG-KEY-puppet'
+      - 'https://yum.puppetlabs.com/RPM-GPG-KEY-puppet-20250406'
     enabled: true
     state: "{{ puppetlabs_repo_source }}"

--- a/tasks/repository/setup-Amazon.yml
+++ b/tasks/repository/setup-Amazon.yml
@@ -4,6 +4,16 @@
 - set_fact:
     el_version: "{{ (ansible_service_mgr == 'systemd') | ternary('7', '6') }}"
 
+- name: Amazonlinux | Add Puppetlabs rpm key
+  rpm_key:
+    state: present
+    key: "{{ item }}"
+  loop:
+    - 'http://yum.puppetlabs.com/RPM-GPG-KEY-puppet'
+    - 'http://yum.puppetlabs.com/RPM-GPG-KEY-puppet-20250406'
+    - 'http://yum.puppetlabs.com/RPM-GPG-KEY-puppetlabs'
+    - 'http://yum.puppetlabs.com/RPM-GPG-KEY-reductive'
+
 - name: Amazonlinux | Add Puppetlabs repository
   yum_repository:
     name: puppet{{ puppet_version }}

--- a/tasks/repository/setup-Amazon.yml
+++ b/tasks/repository/setup-Amazon.yml
@@ -21,8 +21,8 @@
     baseurl: http://yum.puppetlabs.com/puppet{{ puppet_version }}/el/{{ el_version }}/$basearch
     gpgcheck: true
     gpgkey:
-      - 'https://yum.puppetlabs.com/RPM-GPG-KEY-puppet'
-      - 'https://yum.puppetlabs.com/RPM-GPG-KEY-puppet-20250406'
+      - 'http://yum.puppetlabs.com/RPM-GPG-KEY-puppet'
+      - 'http://yum.puppetlabs.com/RPM-GPG-KEY-puppet-20250406'
     enabled: true
     state: present
 
@@ -33,7 +33,7 @@
     baseurl: http://yum.puppetlabs.com/puppet{{ puppet_version }}-nightly/el/{{ el_version }}/SRPMS
     gpgcheck: true
     gpgkey:
-      - 'https://yum.puppetlabs.com/RPM-GPG-KEY-puppet'
-      - 'https://yum.puppetlabs.com/RPM-GPG-KEY-puppet-20250406'
+      - 'http://yum.puppetlabs.com/RPM-GPG-KEY-puppet'
+      - 'http://yum.puppetlabs.com/RPM-GPG-KEY-puppet-20250406'
     enabled: true
     state: "{{ puppetlabs_repo_source }}"

--- a/tasks/repository/setup-CentOS.yml
+++ b/tasks/repository/setup-CentOS.yml
@@ -17,8 +17,8 @@
     baseurl: http://yum.puppetlabs.com/puppet{{ puppet_version }}/el/{{ ansible_distribution_major_version }}/$basearch
     gpgcheck: true
     gpgkey:
-      - 'https://yum.puppetlabs.com/RPM-GPG-KEY-puppet'
-      - 'https://yum.puppetlabs.com/RPM-GPG-KEY-puppet-20250406'
+      - 'http://yum.puppetlabs.com/RPM-GPG-KEY-puppet'
+      - 'http://yum.puppetlabs.com/RPM-GPG-KEY-puppet-20250406'
     enabled: true
     state: present
 
@@ -29,7 +29,7 @@
     baseurl: http://yum.puppetlabs.com/puppet{{ puppet_version }}-nightly/el/{{ ansible_distribution_major_version }}/SRPMS
     gpgcheck: true
     gpgkey:
-      - 'https://yum.puppetlabs.com/RPM-GPG-KEY-puppet'
-      - 'https://yum.puppetlabs.com/RPM-GPG-KEY-puppet-20250406'
+      - 'http://yum.puppetlabs.com/RPM-GPG-KEY-puppet'
+      - 'http://yum.puppetlabs.com/RPM-GPG-KEY-puppet-20250406'
     enabled: true
     state: "{{ puppetlabs_repo_source }}"

--- a/tasks/repository/setup-CentOS.yml
+++ b/tasks/repository/setup-CentOS.yml
@@ -1,5 +1,14 @@
 ---
 # add Puppetlabs repository in CentOS
+- name: CentOS | Add Puppetlabs rpm key
+  rpm_key:
+    state: present
+    key: "{{ item }}"
+  loop:
+    - 'http://yum.puppetlabs.com/RPM-GPG-KEY-puppet'
+    - 'http://yum.puppetlabs.com/RPM-GPG-KEY-puppet-20250406'
+    - 'http://yum.puppetlabs.com/RPM-GPG-KEY-puppetlabs'
+    - 'http://yum.puppetlabs.com/RPM-GPG-KEY-reductive'
 
 - name: CentOS | Add Puppetlabs repository
   yum_repository:

--- a/tasks/repository/setup-CentOS.yml
+++ b/tasks/repository/setup-CentOS.yml
@@ -7,7 +7,9 @@
     description: Puppet {{ puppet_version }} Repository el {{ ansible_distribution_major_version }} - $basearch
     baseurl: http://yum.puppetlabs.com/puppet{{ puppet_version }}/el/{{ ansible_distribution_major_version }}/$basearch
     gpgcheck: true
-    gpgkey: https://yum.puppet.com/RPM-GPG-KEY-puppet
+    gpgkey:
+      - 'https://yum.puppetlabs.com/RPM-GPG-KEY-puppet'
+      - 'https://yum.puppetlabs.com/RPM-GPG-KEY-puppet-20250406'
     enabled: true
     state: present
 
@@ -17,6 +19,8 @@
     description: Puppet {{ puppet_version }} Repository el {{ ansible_distribution_major_version }} - Source
     baseurl: http://yum.puppetlabs.com/puppet{{ puppet_version }}-nightly/el/{{ ansible_distribution_major_version }}/SRPMS
     gpgcheck: true
-    gpgkey: https://yum.puppet.com/RPM-GPG-KEY-puppet
+    gpgkey:
+      - 'https://yum.puppetlabs.com/RPM-GPG-KEY-puppet'
+      - 'https://yum.puppetlabs.com/RPM-GPG-KEY-puppet-20250406'
     enabled: true
     state: "{{ puppetlabs_repo_source }}"

--- a/tasks/repository/setup-Debian.yml
+++ b/tasks/repository/setup-Debian.yml
@@ -3,16 +3,26 @@
 
 - name: Debian | Add Puppetlabs apt key
   apt_key:
-    data: "{{ lookup('url', 'https://apt.puppetlabs.com/DEB-GPG-KEY-puppet', split_lines=False) }}"
+    data: "{{ lookup('url', item, split_lines=False) }}"
     state: present
+  loop:
+    - 'https://apt.puppetlabs.com/DEB-GPG-KEY-puppet'
+    - 'https://apt.puppetlabs.com/DEB-GPG-KEY-puppet-20250406'
+    - 'https://apt.puppetlabs.com/DEB-GPG-KEY-puppetlabs'
+    - 'https://apt.puppetlabs.com/DEB-GPG-KEY-reductive'
   when: ansible_distribution == "Debian" and ansible_distribution_major_version >= '08'
 
 - name: old Debian | Add Puppetlabs apt key for old Debian
   shell: |
     set -o pipefail
-    curl -s https://apt.puppetlabs.com/DEB-GPG-KEY-puppet | apt-key add - > /etc/apt/trusted.gpg.d/puppetlabs.output
+    curl -s https://apt.puppetlabs.com/{{ item }} | apt-key add - > /etc/apt/trusted.gpg.d/{{ item }}.output
   args:
-    creates: /etc/apt/trusted.gpg.d/puppetlabs.output
+    creates: /etc/apt/trusted.gpg.d/{{ item }}.output
+  loop:
+    - 'puppet'
+    - 'puppet-20250406'
+    - 'puppetlabs'
+    - 'reductive'
   when: ansible_distribution == "Debian" and ansible_distribution_major_version < '08'
 
 - name: Debian | Add Puppetlabs repository

--- a/tasks/repository/setup-Debian.yml
+++ b/tasks/repository/setup-Debian.yml
@@ -10,20 +10,6 @@
     - 'https://apt.puppetlabs.com/DEB-GPG-KEY-puppet-20250406'
     - 'https://apt.puppetlabs.com/DEB-GPG-KEY-puppetlabs'
     - 'https://apt.puppetlabs.com/DEB-GPG-KEY-reductive'
-  when: ansible_distribution == "Debian" and ansible_distribution_major_version >= '08'
-
-- name: old Debian | Add Puppetlabs apt key for old Debian
-  shell: |
-    set -o pipefail
-    curl -s https://apt.puppetlabs.com/{{ item }} | apt-key add - > /etc/apt/trusted.gpg.d/{{ item }}.output
-  args:
-    creates: /etc/apt/trusted.gpg.d/{{ item }}.output
-  loop:
-    - 'puppet'
-    - 'puppet-20250406'
-    - 'puppetlabs'
-    - 'reductive'
-  when: ansible_distribution == "Debian" and ansible_distribution_major_version < '08'
 
 - name: Debian | Add Puppetlabs repository
   apt_repository:

--- a/tasks/repository/setup-Fedora.yml
+++ b/tasks/repository/setup-Fedora.yml
@@ -17,8 +17,8 @@
     baseurl: http://yum.puppetlabs.com/puppet{{ puppet_version }}/fedora/{{ ansible_distribution_major_version }}/$basearch
     gpgcheck: true
     gpgkey:
-      - 'https://yum.puppetlabs.com/RPM-GPG-KEY-puppet'
-      - 'https://yum.puppetlabs.com/RPM-GPG-KEY-puppet-20250406'
+      - 'http://yum.puppetlabs.com/RPM-GPG-KEY-puppet'
+      - 'http://yum.puppetlabs.com/RPM-GPG-KEY-puppet-20250406'
     enabled: true
     state: present
 
@@ -29,7 +29,7 @@
     baseurl: http://yum.puppetlabs.com/puppet{{ puppet_version }}-nightly/fedora/{{ ansible_distribution_major_version }}/SRPMS
     gpgcheck: true
     gpgkey:
-      - 'https://yum.puppetlabs.com/RPM-GPG-KEY-puppet'
-      - 'https://yum.puppetlabs.com/RPM-GPG-KEY-puppet-20250406'
+      - 'http://yum.puppetlabs.com/RPM-GPG-KEY-puppet'
+      - 'http://yum.puppetlabs.com/RPM-GPG-KEY-puppet-20250406'
     enabled: true
     state: "{{ puppetlabs_repo_source }}"

--- a/tasks/repository/setup-Fedora.yml
+++ b/tasks/repository/setup-Fedora.yml
@@ -1,5 +1,14 @@
 ---
 # add Puppetlabs repository in Fedora
+- name: Fedora | Add Puppetlabs rpm key
+  rpm_key:
+    state: present
+    key: "{{ item }}"
+  loop:
+    - 'http://yum.puppetlabs.com/RPM-GPG-KEY-puppet'
+    - 'http://yum.puppetlabs.com/RPM-GPG-KEY-puppet-20250406'
+    - 'http://yum.puppetlabs.com/RPM-GPG-KEY-puppetlabs'
+    - 'http://yum.puppetlabs.com/RPM-GPG-KEY-reductive'
 
 - name: Fedora | Add Puppetlabs repository
   yum_repository:

--- a/tasks/repository/setup-Fedora.yml
+++ b/tasks/repository/setup-Fedora.yml
@@ -7,7 +7,9 @@
     description: Puppet {{ puppet_version }} Repository fedora {{ ansible_distribution_major_version }} - $basearch
     baseurl: http://yum.puppetlabs.com/puppet{{ puppet_version }}/fedora/{{ ansible_distribution_major_version }}/$basearch
     gpgcheck: true
-    gpgkey: https://yum.puppet.com/RPM-GPG-KEY-puppet
+    gpgkey:
+      - 'https://yum.puppetlabs.com/RPM-GPG-KEY-puppet'
+      - 'https://yum.puppetlabs.com/RPM-GPG-KEY-puppet-20250406'
     enabled: true
     state: present
 
@@ -17,6 +19,8 @@
     description: Puppet {{ puppet_version }} Repository fedora {{ ansible_distribution_major_version }} - Source
     baseurl: http://yum.puppetlabs.com/puppet{{ puppet_version }}-nightly/fedora/{{ ansible_distribution_major_version }}/SRPMS
     gpgcheck: true
-    gpgkey: https://yum.puppet.com/RPM-GPG-KEY-puppet
+    gpgkey:
+      - 'https://yum.puppetlabs.com/RPM-GPG-KEY-puppet'
+      - 'https://yum.puppetlabs.com/RPM-GPG-KEY-puppet-20250406'
     enabled: true
     state: "{{ puppetlabs_repo_source }}"

--- a/tasks/repository/setup-Ubuntu.yml
+++ b/tasks/repository/setup-Ubuntu.yml
@@ -3,17 +3,27 @@
 
 - name: Ubuntu | Add Puppetlabs apt key
   apt_key:
-    data: "{{ lookup('url', 'https://apt.puppetlabs.com/DEB-GPG-KEY-puppet', split_lines=False) }}"
+    data: "{{ lookup('url', item, split_lines=False) }}"
     state: present
+  loop:
+    - 'https://apt.puppetlabs.com/DEB-GPG-KEY-puppet'
+    - 'https://apt.puppetlabs.com/DEB-GPG-KEY-puppet-20250406'
+    - 'https://apt.puppetlabs.com/DEB-GPG-KEY-puppetlabs'
+    - 'https://apt.puppetlabs.com/DEB-GPG-KEY-reductive'
   when: ansible_distribution_major_version >= '16.04'
 
 - name: old Ubuntu | Add Puppetlabs apt key for old Debian
   shell: |
     set -o pipefail
-    curl -s https://apt.puppetlabs.com/DEB-GPG-KEY-puppet | apt-key add - > /etc/apt/trusted.gpg.d/puppetlabs.output
+    curl -s https://apt.puppetlabs.com/{{ item }} | apt-key add - > /etc/apt/trusted.gpg.d/{{ item }}.output
   args:
-    creates: /etc/apt/trusted.gpg.d/puppetlabs.output
+    creates: /etc/apt/trusted.gpg.d/{{ item }}.output
     executable: /bin/bash
+  loop:
+    - 'puppet'
+    - 'puppet-20250406'
+    - 'puppetlabs'
+    - 'reductive'
   when: ansible_distribution_major_version < '16.04'
 
 - name: Ubuntu | Add Puppetlabs repository for Ubuntu

--- a/tasks/repository/setup-Ubuntu.yml
+++ b/tasks/repository/setup-Ubuntu.yml
@@ -10,21 +10,6 @@
     - 'https://apt.puppetlabs.com/DEB-GPG-KEY-puppet-20250406'
     - 'https://apt.puppetlabs.com/DEB-GPG-KEY-puppetlabs'
     - 'https://apt.puppetlabs.com/DEB-GPG-KEY-reductive'
-  when: ansible_distribution_major_version >= '16.04'
-
-- name: old Ubuntu | Add Puppetlabs apt key for old Debian
-  shell: |
-    set -o pipefail
-    curl -s https://apt.puppetlabs.com/{{ item }} | apt-key add - > /etc/apt/trusted.gpg.d/{{ item }}.output
-  args:
-    creates: /etc/apt/trusted.gpg.d/{{ item }}.output
-    executable: /bin/bash
-  loop:
-    - 'puppet'
-    - 'puppet-20250406'
-    - 'puppetlabs'
-    - 'reductive'
-  when: ansible_distribution_major_version < '16.04'
 
 - name: Ubuntu | Add Puppetlabs repository for Ubuntu
   apt_repository:


### PR DESCRIPTION
Actually -- I decided to go ahead and do it.  HOWEVER there is one big caveat with this one -- I do not have any available access to older Ubuntu installs or Debian at all.  So this is only tested under Ubuntu 20.

Note: so far the only thing I have run into in the puppet 6 chain that is signed with the new key is puppetserver.  So most likely not many folk are 'noticing' this yet.  =)

This branch -does- include the fixes from the centos one btw, so please consider the Centos PR first before considering merging this.  If you need me to separate the Debian fixes so they don't include the centos ones (ie if you want the debian ones but not the centos ones) just let me know.